### PR TITLE
Fix nil comparison error

### DIFF
--- a/gamesense.pub loader
+++ b/gamesense.pub loader
@@ -1558,7 +1558,7 @@ RunService.RenderStepped:Connect(function()
     if getgenv().enabled and getgenv().active and LocalPlayer.Character then
         local rootPart = LocalPlayer.Character:FindFirstChild("HumanoidRootPart")
         if rootPart then
-            local closestPlayer, closestDistance = nil, getgenv().range
+            local closestPlayer, closestDistance = nil, tonumber(getgenv().range) or math.huge
 
             for _, player in ipairs(Players:GetPlayers()) do
                 if player ~= LocalPlayer and player.Character and not getgenv().whitelist[player.Name] then
@@ -1616,9 +1616,12 @@ RunService.RenderStepped:Connect(function()
         if backpack then
             for _, tool in ipairs(backpack:GetChildren()) do
                 local ammo = tool:FindFirstChild("Ammo")
-                if ammo and ammo:IsA("ValueBase") and ammo.Value < 5 then
-                    hasLowAmmo = true
-                    break
+                if ammo and ammo:IsA("ValueBase") then
+                    local ammoValue = tonumber(ammo.Value)
+                    if ammoValue and ammoValue < 5 then
+                        hasLowAmmo = true
+                        break
+                    end
                 end
             end
         end


### PR DESCRIPTION
Add nil checks and type conversions to prevent "attempt to compare nil < number" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc2c0e59-ae42-4e8c-9521-c0f67e86524c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc2c0e59-ae42-4e8c-9521-c0f67e86524c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

